### PR TITLE
Add support for vector type based on the specification

### DIFF
--- a/xdl_rs/src/conversions/base_type.rs
+++ b/xdl_rs/src/conversions/base_type.rs
@@ -1,4 +1,27 @@
-use crate::{xdl_primitive::XdlPrimitive, XdlMetadata, XdlType};
+use crate::{
+    xdl_primitive::{XdlPrimitive, XdlPrimitiveMetadata},
+    xdl_struct::{XdlStruct, XdlStructMetadata},
+    xdl_vec::{XdlVec, XdlVecMetadata},
+    XdlMetadata, XdlType,
+};
+
+impl From<XdlPrimitiveMetadata> for XdlMetadata {
+    fn from(value: XdlPrimitiveMetadata) -> Self {
+        XdlMetadata::Primitive(value)
+    }
+}
+
+impl From<XdlVecMetadata> for XdlMetadata {
+    fn from(value: XdlVecMetadata) -> Self {
+        XdlMetadata::Vec(value)
+    }
+}
+
+impl From<XdlStructMetadata> for XdlMetadata {
+    fn from(value: XdlStructMetadata) -> Self {
+        XdlMetadata::Struct(value)
+    }
+}
 
 impl From<&XdlType> for XdlMetadata {
     fn from(value: &XdlType) -> Self {
@@ -13,5 +36,17 @@ impl From<&XdlType> for XdlMetadata {
 impl From<XdlPrimitive> for XdlType {
     fn from(value: XdlPrimitive) -> Self {
         XdlType::Primitive(value)
+    }
+}
+
+impl From<XdlVec> for XdlType {
+    fn from(value: XdlVec) -> Self {
+        XdlType::Vec(value)
+    }
+}
+
+impl From<XdlStruct> for XdlType {
+    fn from(value: XdlStruct) -> Self {
+        XdlType::Struct(value)
     }
 }

--- a/xdl_rs/src/conversions/base_type.rs
+++ b/xdl_rs/src/conversions/base_type.rs
@@ -1,0 +1,17 @@
+use crate::{xdl_primitive::XdlPrimitive, XdlMetadata, XdlType};
+
+impl From<&XdlType> for XdlMetadata {
+    fn from(value: &XdlType) -> Self {
+        match value {
+            XdlType::Primitive(x) => XdlMetadata::Primitive(x.into()),
+            XdlType::Vec(x) => XdlMetadata::Vec(x.into()),
+            XdlType::Struct(_x) => todo!(),
+        }
+    }
+}
+
+impl From<XdlPrimitive> for XdlType {
+    fn from(value: XdlPrimitive) -> Self {
+        XdlType::Primitive(value)
+    }
+}

--- a/xdl_rs/src/conversions/mod.rs
+++ b/xdl_rs/src/conversions/mod.rs
@@ -1,0 +1,3 @@
+mod base_type;
+mod primitive;
+mod vec;

--- a/xdl_rs/src/conversions/primitive.rs
+++ b/xdl_rs/src/conversions/primitive.rs
@@ -1,0 +1,153 @@
+use crate::xdl_primitive::{XdlPrimitive, XdlPrimitiveMetadata};
+
+impl From<&XdlPrimitive> for XdlPrimitiveMetadata {
+    fn from(x: &XdlPrimitive) -> Self {
+        match x {
+            XdlPrimitive::Bool(_) => XdlPrimitiveMetadata::Bool,
+            XdlPrimitive::U8(_) => XdlPrimitiveMetadata::U8,
+            XdlPrimitive::U16(_) => XdlPrimitiveMetadata::U16,
+            XdlPrimitive::U32(_) => XdlPrimitiveMetadata::U32,
+            XdlPrimitive::U64(_) => XdlPrimitiveMetadata::U64,
+            XdlPrimitive::U128(_) => XdlPrimitiveMetadata::U128,
+            XdlPrimitive::U256(_) => XdlPrimitiveMetadata::U256,
+            XdlPrimitive::I8(_) => XdlPrimitiveMetadata::I8,
+            XdlPrimitive::I16(_) => XdlPrimitiveMetadata::I16,
+            XdlPrimitive::I32(_) => XdlPrimitiveMetadata::I32,
+            XdlPrimitive::I64(_) => XdlPrimitiveMetadata::I64,
+            XdlPrimitive::I128(_) => XdlPrimitiveMetadata::I128,
+            XdlPrimitive::I256(_) => XdlPrimitiveMetadata::I256,
+            XdlPrimitive::F32(_) => XdlPrimitiveMetadata::F32,
+            XdlPrimitive::F64(_) => XdlPrimitiveMetadata::F64,
+            XdlPrimitive::String(_) => XdlPrimitiveMetadata::String,
+        }
+    }
+}
+
+macro_rules! xdl_primitive_from_impl {
+    ($ty:ty, $xdl_type:tt) => {
+        impl From<$ty> for XdlPrimitive {
+            fn from(x: $ty) -> Self {
+                XdlPrimitive::$xdl_type(x)
+            }
+        }
+    };
+}
+
+xdl_primitive_from_impl!(bool, Bool);
+
+xdl_primitive_from_impl!(u8, U8);
+xdl_primitive_from_impl!(u16, U16);
+xdl_primitive_from_impl!(u32, U32);
+xdl_primitive_from_impl!(u64, U64);
+xdl_primitive_from_impl!(u128, U128);
+
+xdl_primitive_from_impl!(i8, I8);
+xdl_primitive_from_impl!(i16, I16);
+xdl_primitive_from_impl!(i32, I32);
+xdl_primitive_from_impl!(i64, I64);
+xdl_primitive_from_impl!(i128, I128);
+
+xdl_primitive_from_impl!(f32, F32);
+xdl_primitive_from_impl!(f64, F64);
+
+xdl_primitive_from_impl!(String, String);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    macro_rules! from_primitive_test {
+        ($ty:ty, $xdl_type:tt, $test_num:expr) => {
+            let value: $ty = $test_num;
+            let primitive: XdlPrimitive = value.clone().into();
+            assert_eq!(primitive, XdlPrimitive::$xdl_type(value));
+        };
+    }
+
+    #[test]
+    fn primitive_from_native_works() {
+        from_primitive_test!(bool, Bool, true);
+        from_primitive_test!(bool, Bool, false);
+        from_primitive_test!(u8, U8, 42);
+        from_primitive_test!(u16, U16, 42);
+        from_primitive_test!(u32, U32, 42);
+        from_primitive_test!(u64, U64, 42);
+        from_primitive_test!(u128, U128, 42);
+        from_primitive_test!(i8, I8, 42);
+        from_primitive_test!(i16, I16, 42);
+        from_primitive_test!(i32, I32, 42);
+        from_primitive_test!(i64, I64, 42);
+        from_primitive_test!(i128, I128, 42);
+        from_primitive_test!(f32, F32, 42.0);
+        from_primitive_test!(f64, F64, 42.0);
+        from_primitive_test!(String, String, "Hello World".to_string());
+    }
+
+    #[test]
+    fn primitve_metadata_from_primitive_works() {
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::Bool(true)),
+            XdlPrimitiveMetadata::Bool
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U8(1)),
+            XdlPrimitiveMetadata::U8
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U16(1)),
+            XdlPrimitiveMetadata::U16
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U32(1)),
+            XdlPrimitiveMetadata::U32
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U64(1)),
+            XdlPrimitiveMetadata::U64
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U128(1)),
+            XdlPrimitiveMetadata::U128
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::U256(())),
+            XdlPrimitiveMetadata::U256
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I8(1)),
+            XdlPrimitiveMetadata::I8
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I16(1)),
+            XdlPrimitiveMetadata::I16
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I32(1)),
+            XdlPrimitiveMetadata::I32
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I64(1)),
+            XdlPrimitiveMetadata::I64
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I128(1)),
+            XdlPrimitiveMetadata::I128
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::I256(())),
+            XdlPrimitiveMetadata::I256
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::F32(1.0)),
+            XdlPrimitiveMetadata::F32
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::F64(1.0)),
+            XdlPrimitiveMetadata::F64
+        );
+        assert_eq!(
+            XdlPrimitiveMetadata::from(&XdlPrimitive::String("test".to_string())),
+            XdlPrimitiveMetadata::String
+        );
+    }
+}

--- a/xdl_rs/src/conversions/vec.rs
+++ b/xdl_rs/src/conversions/vec.rs
@@ -1,0 +1,7 @@
+use crate::xdl_vec::{XdlVec, XdlVecMetadata};
+
+impl From<&XdlVec> for XdlVecMetadata {
+    fn from(value: &XdlVec) -> Self {
+        Self::from_boxed_type(value.inner_type.clone())
+    }
+}

--- a/xdl_rs/src/lib.rs
+++ b/xdl_rs/src/lib.rs
@@ -1,3 +1,4 @@
+mod conversions;
 mod xdl_primitive;
 mod xdl_struct;
 mod xdl_vec;
@@ -33,16 +34,6 @@ impl Serialize for XdlMetadata {
             XdlMetadata::Primitive(x) => x.serialize(writer),
             XdlMetadata::Vec(x) => x.serialize(writer),
             XdlMetadata::Struct(_x) => todo!(),
-        }
-    }
-}
-
-impl From<&XdlType> for XdlMetadata {
-    fn from(value: &XdlType) -> Self {
-        match value {
-            XdlType::Primitive(x) => XdlMetadata::Primitive(x.into()),
-            XdlType::Vec(x) => XdlMetadata::Vec(x.into()),
-            XdlType::Struct(_x) => todo!(),
         }
     }
 }

--- a/xdl_rs/src/lib.rs
+++ b/xdl_rs/src/lib.rs
@@ -59,7 +59,7 @@ impl DeserializeType for XdlType {
     fn deserialize_type(metadata: &XdlMetadata, reader: &mut impl Read) -> io::Result<XdlType> {
         match metadata {
             XdlMetadata::Primitive(x) => XdlPrimitive::deserialize_primitive(x, reader),
-            XdlMetadata::Vec(_) => todo!(),
+            XdlMetadata::Vec(x) => XdlVec::deserialize_type(&x.inner_type, reader),
             XdlMetadata::Struct(_) => todo!(),
         }
     }

--- a/xdl_rs/src/xdl_primitive/primitive.rs
+++ b/xdl_rs/src/xdl_primitive/primitive.rs
@@ -23,12 +23,6 @@ pub enum XdlPrimitive {
     String(String),
 }
 
-impl From<XdlPrimitive> for XdlType {
-    fn from(value: XdlPrimitive) -> Self {
-        XdlType::Primitive(value)
-    }
-}
-
 impl Serialize for XdlPrimitive {
     fn serialize(&self, writer: &mut impl Write) -> io::Result<()> {
         match self {
@@ -96,32 +90,3 @@ impl XdlPrimitive {
         .map(|x| x.into())
     }
 }
-
-macro_rules! xdl_primitive_from_impl {
-    ($ty:ty, $xdl_type:tt) => {
-        impl From<$ty> for XdlPrimitive {
-            fn from(x: $ty) -> Self {
-                XdlPrimitive::$xdl_type(x)
-            }
-        }
-    };
-}
-
-xdl_primitive_from_impl!(bool, Bool);
-
-xdl_primitive_from_impl!(u8, U8);
-xdl_primitive_from_impl!(u16, U16);
-xdl_primitive_from_impl!(u32, U32);
-xdl_primitive_from_impl!(u64, U64);
-xdl_primitive_from_impl!(u128, U128);
-
-xdl_primitive_from_impl!(i8, I8);
-xdl_primitive_from_impl!(i16, I16);
-xdl_primitive_from_impl!(i32, I32);
-xdl_primitive_from_impl!(i64, I64);
-xdl_primitive_from_impl!(i128, I128);
-
-xdl_primitive_from_impl!(f32, F32);
-xdl_primitive_from_impl!(f64, F64);
-
-xdl_primitive_from_impl!(String, String);

--- a/xdl_rs/src/xdl_primitive/primitive_metadata.rs
+++ b/xdl_rs/src/xdl_primitive/primitive_metadata.rs
@@ -1,4 +1,3 @@
-use super::XdlPrimitive;
 use crate::Serialize;
 use byteorder::WriteBytesExt;
 use std::io::{self, Write};

--- a/xdl_rs/src/xdl_primitive/primitive_metadata.rs
+++ b/xdl_rs/src/xdl_primitive/primitive_metadata.rs
@@ -59,29 +59,6 @@ impl TryFrom<u8> for XdlPrimitiveMetadata {
     }
 }
 
-impl From<&XdlPrimitive> for XdlPrimitiveMetadata {
-    fn from(x: &XdlPrimitive) -> Self {
-        match x {
-            XdlPrimitive::Bool(_) => XdlPrimitiveMetadata::Bool,
-            XdlPrimitive::U8(_) => XdlPrimitiveMetadata::U8,
-            XdlPrimitive::U16(_) => XdlPrimitiveMetadata::U16,
-            XdlPrimitive::U32(_) => XdlPrimitiveMetadata::U32,
-            XdlPrimitive::U64(_) => XdlPrimitiveMetadata::U64,
-            XdlPrimitive::U128(_) => XdlPrimitiveMetadata::U128,
-            XdlPrimitive::U256(_) => XdlPrimitiveMetadata::U256,
-            XdlPrimitive::I8(_) => XdlPrimitiveMetadata::I8,
-            XdlPrimitive::I16(_) => XdlPrimitiveMetadata::I16,
-            XdlPrimitive::I32(_) => XdlPrimitiveMetadata::I32,
-            XdlPrimitive::I64(_) => XdlPrimitiveMetadata::I64,
-            XdlPrimitive::I128(_) => XdlPrimitiveMetadata::I128,
-            XdlPrimitive::I256(_) => XdlPrimitiveMetadata::I256,
-            XdlPrimitive::F32(_) => XdlPrimitiveMetadata::F32,
-            XdlPrimitive::F64(_) => XdlPrimitiveMetadata::F64,
-            XdlPrimitive::String(_) => XdlPrimitiveMetadata::String,
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -155,73 +132,5 @@ mod test {
         let err = XdlPrimitiveMetadata::try_from(16).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(err.to_string(), "invalid primitive metadata");
-    }
-
-    #[test]
-    fn metadata_from_primitive_works() {
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::Bool(true)),
-            XdlPrimitiveMetadata::Bool
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U8(1)),
-            XdlPrimitiveMetadata::U8
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U16(1)),
-            XdlPrimitiveMetadata::U16
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U32(1)),
-            XdlPrimitiveMetadata::U32
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U64(1)),
-            XdlPrimitiveMetadata::U64
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U128(1)),
-            XdlPrimitiveMetadata::U128
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::U256(())),
-            XdlPrimitiveMetadata::U256
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I8(1)),
-            XdlPrimitiveMetadata::I8
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I16(1)),
-            XdlPrimitiveMetadata::I16
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I32(1)),
-            XdlPrimitiveMetadata::I32
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I64(1)),
-            XdlPrimitiveMetadata::I64
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I128(1)),
-            XdlPrimitiveMetadata::I128
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::I256(())),
-            XdlPrimitiveMetadata::I256
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::F32(1.0)),
-            XdlPrimitiveMetadata::F32
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::F64(1.0)),
-            XdlPrimitiveMetadata::F64
-        );
-        assert_eq!(
-            XdlPrimitiveMetadata::from(&XdlPrimitive::String("test".to_string())),
-            XdlPrimitiveMetadata::String
-        );
     }
 }

--- a/xdl_rs/src/xdl_primitive/primitive_test.rs
+++ b/xdl_rs/src/xdl_primitive/primitive_test.rs
@@ -198,26 +198,3 @@ fn string_deserialize_works() {
     let primitive = XdlType::deserialize_type(&metadata, &mut reader).unwrap();
     assert_eq!(primitive, expected);
 }
-
-#[test]
-fn test_xdl_primitive_from_bool() {
-    let value: bool = true;
-    let primitive: XdlPrimitive = value.into();
-    assert_eq!(primitive, XdlPrimitive::Bool(true));
-}
-
-#[test]
-fn test_xdl_primitive_from_u8() {
-    let value: u8 = 42;
-    let primitive: XdlPrimitive = value.into();
-    assert_eq!(primitive, XdlPrimitive::U8(42));
-}
-
-// Add similar tests for other primitive types...
-
-#[test]
-fn test_xdl_primitive_from_string() {
-    let value: String = "Hello, World!".to_string();
-    let primitive: XdlPrimitive = value.into();
-    assert_eq!(primitive, XdlPrimitive::String("Hello, World!".to_string()));
-}

--- a/xdl_rs/src/xdl_vec/vec.rs
+++ b/xdl_rs/src/xdl_vec/vec.rs
@@ -62,12 +62,12 @@ pub struct ElementsNotHomogenousError;
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::{
         xdl_primitive::{XdlPrimitive, XdlPrimitiveMetadata},
         xdl_vec::XdlVecMetadata,
     };
-
-    use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn serialize_vec_primitive_works() {
@@ -119,5 +119,25 @@ mod test {
         expected.extend_from_slice(&TEST_NUM.to_le_bytes());
 
         assert_eq!(writer, expected);
+    }
+
+    #[test]
+    fn deserialize_vec_primitive_works() {
+        const TEST_NUM: i32 = 42;
+        let mut data = vec![];
+        data.extend_from_slice(&1u16.to_le_bytes());
+        data.extend_from_slice(&TEST_NUM.to_le_bytes());
+        let mut reader = Cursor::new(data);
+
+        let metadata = XdlVecMetadata::new(XdlPrimitiveMetadata::I32.into());
+        let expected = XdlVec::new(
+            XdlPrimitiveMetadata::I32.into(),
+            vec![XdlType::Primitive(XdlPrimitive::I32(TEST_NUM))],
+        )
+        .unwrap();
+
+        let vec = XdlType::deserialize_type(&(metadata.into()), &mut reader).unwrap();
+
+        assert_eq!(vec, expected.into());
     }
 }

--- a/xdl_rs/src/xdl_vec/vec.rs
+++ b/xdl_rs/src/xdl_vec/vec.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Write};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct XdlVec {
-    pub(super) inner_type: Box<XdlMetadata>,
+    pub(crate) inner_type: Box<XdlMetadata>,
     elements: Vec<XdlType>,
 }
 

--- a/xdl_rs/src/xdl_vec/vec_metadata.rs
+++ b/xdl_rs/src/xdl_vec/vec_metadata.rs
@@ -1,4 +1,3 @@
-use super::XdlVec;
 use crate::{xdl_primitive::XdlPrimitiveMetadata, DeserializeMetadata, Serialize, XdlMetadata};
 use byteorder::WriteBytesExt;
 use std::io::{self, Write};
@@ -8,19 +7,6 @@ pub const VEC_METADATA_DISCRIMINANT: u8 = XdlPrimitiveMetadata::String as u8 + 1
 #[derive(Debug, Clone, PartialEq)]
 pub struct XdlVecMetadata {
     inner_type: Box<XdlMetadata>,
-}
-
-impl Serialize for XdlVecMetadata {
-    fn serialize(&self, writer: &mut impl Write) -> io::Result<()> {
-        writer.write_u8(VEC_METADATA_DISCRIMINANT)?;
-        self.inner_type.serialize(writer)
-    }
-}
-
-impl DeserializeMetadata for XdlVecMetadata {
-    fn deserialize_metadata(reader: &mut impl io::Read) -> io::Result<XdlMetadata> {
-        todo!()
-    }
 }
 
 impl XdlVecMetadata {
@@ -35,18 +21,27 @@ impl XdlVecMetadata {
     }
 }
 
-impl From<&XdlVec> for XdlVecMetadata {
-    fn from(value: &XdlVec) -> Self {
-        Self::from_boxed_type(value.inner_type.clone())
+impl Serialize for XdlVecMetadata {
+    fn serialize(&self, writer: &mut impl Write) -> io::Result<()> {
+        writer.write_u8(VEC_METADATA_DISCRIMINANT)?;
+        self.inner_type.serialize(writer)
+    }
+}
+
+impl DeserializeMetadata for XdlVecMetadata {
+    fn deserialize_metadata(reader: &mut impl io::Read) -> io::Result<XdlMetadata> {
+        let inner_type = XdlMetadata::deserialize_metadata(reader)?;
+        Ok(XdlMetadata::Vec(XdlVecMetadata::new(inner_type)))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use io::Cursor;
 
     #[test]
-    fn primitive_metadata_works() {
+    fn primitive_metadata_serialize_works() {
         let vec_i32_metadata =
             XdlVecMetadata::new(XdlMetadata::Primitive(XdlPrimitiveMetadata::I32));
         let vec_string_metadata = XdlVecMetadata::from_boxed_type(Box::new(
@@ -69,7 +64,34 @@ mod test {
     }
 
     #[test]
-    fn nested_vec_metadata_works() {
+    fn primitive_metadata_deserialize_works() {
+        let data = vec![
+            VEC_METADATA_DISCRIMINANT,
+            XdlPrimitiveMetadata::I32 as u8,
+            VEC_METADATA_DISCRIMINANT,
+            XdlPrimitiveMetadata::String as u8,
+        ];
+        let mut reader = Cursor::new(data);
+
+        let vec_i32_metadata = XdlMetadata::deserialize_metadata(&mut reader).unwrap();
+        let vec_string_metadata = XdlMetadata::deserialize_metadata(&mut reader).unwrap();
+
+        assert_eq!(
+            vec_i32_metadata,
+            XdlMetadata::Vec(XdlVecMetadata::new(XdlMetadata::Primitive(
+                XdlPrimitiveMetadata::I32
+            )))
+        );
+        assert_eq!(
+            vec_string_metadata,
+            XdlMetadata::Vec(XdlVecMetadata::new(XdlMetadata::Primitive(
+                XdlPrimitiveMetadata::String
+            )))
+        )
+    }
+
+    #[test]
+    fn nested_vec_metadata_serialize_works() {
         let vec_vec_i32_metadata = XdlVecMetadata {
             inner_type: Box::new(XdlMetadata::Vec(XdlVecMetadata {
                 inner_type: Box::new(XdlMetadata::Primitive(XdlPrimitiveMetadata::I32)),
@@ -87,5 +109,23 @@ mod test {
                 XdlPrimitiveMetadata::I32 as u8
             ]
         )
+    }
+
+    #[test]
+    fn nested_vec_metadata_deserialize_works() {
+        let data = vec![
+            VEC_METADATA_DISCRIMINANT,
+            VEC_METADATA_DISCRIMINANT,
+            XdlPrimitiveMetadata::I32 as u8,
+        ];
+        let mut reader = Cursor::new(data);
+
+        let vec_vec_i32_metadata = XdlMetadata::deserialize_metadata(&mut reader).unwrap();
+
+        let expected_metadata = XdlMetadata::Vec(XdlVecMetadata::new(XdlMetadata::Vec(
+            XdlVecMetadata::new(XdlMetadata::Primitive(XdlPrimitiveMetadata::I32)),
+        )));
+
+        assert_eq!(vec_vec_i32_metadata, expected_metadata);
     }
 }

--- a/xdl_rs/src/xdl_vec/vec_metadata.rs
+++ b/xdl_rs/src/xdl_vec/vec_metadata.rs
@@ -6,7 +6,7 @@ pub const VEC_METADATA_DISCRIMINANT: u8 = XdlPrimitiveMetadata::String as u8 + 1
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct XdlVecMetadata {
-    inner_type: Box<XdlMetadata>,
+    pub(crate) inner_type: Box<XdlMetadata>,
 }
 
 impl XdlVecMetadata {


### PR DESCRIPTION
This PR has two main features:

1. Moves most of the explicit conversions (trait From implementations) into their own module and submodule
2. Properly implements the Vec type as per the specification document. 

Both of these features have extensive unit tests to ensure that they work as expected, with the main thing not being tested being the sad path yet.