### PR TITLE
Merge in string utility functions

### DIFF
--- a/xdl_rs/src/conversions/base_type.rs
+++ b/xdl_rs/src/conversions/base_type.rs
@@ -2,12 +2,19 @@ use crate::{
     xdl_primitive::{XdlPrimitive, XdlPrimitiveMetadata},
     xdl_struct::{XdlStruct, XdlStructMetadata},
     xdl_vec::{XdlVec, XdlVecMetadata},
-    XdlMetadata, XdlType,
+    IntoBaseMetadata, IntoBaseType, XdlMetadata, XdlType,
 };
 
 impl From<XdlPrimitiveMetadata> for XdlMetadata {
     fn from(value: XdlPrimitiveMetadata) -> Self {
         XdlMetadata::Primitive(value)
+    }
+}
+
+// TODO: Test this
+impl IntoBaseMetadata for XdlPrimitiveMetadata {
+    fn into_base_metadata(self) -> XdlMetadata {
+        self.into()
     }
 }
 
@@ -17,9 +24,23 @@ impl From<XdlVecMetadata> for XdlMetadata {
     }
 }
 
+// TODO: Test this
+impl IntoBaseMetadata for XdlVecMetadata {
+    fn into_base_metadata(self) -> XdlMetadata {
+        self.into()
+    }
+}
+
 impl From<XdlStructMetadata> for XdlMetadata {
     fn from(value: XdlStructMetadata) -> Self {
         XdlMetadata::Struct(value)
+    }
+}
+
+// TODO: Test this
+impl IntoBaseMetadata for XdlStructMetadata {
+    fn into_base_metadata(self) -> XdlMetadata {
+        self.into()
     }
 }
 
@@ -39,14 +60,35 @@ impl From<XdlPrimitive> for XdlType {
     }
 }
 
+// TODO: Test this
+impl IntoBaseType for XdlPrimitive {
+    fn into_base_type(self) -> XdlType {
+        self.into()
+    }
+}
+
 impl From<XdlVec> for XdlType {
     fn from(value: XdlVec) -> Self {
         XdlType::Vec(value)
     }
 }
 
+// TODO: Test this
+impl IntoBaseType for XdlVec {
+    fn into_base_type(self) -> XdlType {
+        self.into()
+    }
+}
+
 impl From<XdlStruct> for XdlType {
     fn from(value: XdlStruct) -> Self {
         XdlType::Struct(value)
+    }
+}
+
+// TODO: Test this
+impl IntoBaseType for XdlStruct {
+    fn into_base_type(self) -> XdlType {
+        self.into()
     }
 }

--- a/xdl_rs/src/conversions/primitive.rs
+++ b/xdl_rs/src/conversions/primitive.rs
@@ -23,7 +23,7 @@ impl From<&XdlPrimitive> for XdlPrimitiveMetadata {
     }
 }
 
-macro_rules! xdl_primitive_from_impl {
+macro_rules! xdl_primitive_from_native_impl {
     ($ty:ty, $xdl_type:tt) => {
         impl From<$ty> for XdlPrimitive {
             fn from(x: $ty) -> Self {
@@ -33,30 +33,30 @@ macro_rules! xdl_primitive_from_impl {
     };
 }
 
-xdl_primitive_from_impl!(bool, Bool);
+xdl_primitive_from_native_impl!(bool, Bool);
 
-xdl_primitive_from_impl!(u8, U8);
-xdl_primitive_from_impl!(u16, U16);
-xdl_primitive_from_impl!(u32, U32);
-xdl_primitive_from_impl!(u64, U64);
-xdl_primitive_from_impl!(u128, U128);
+xdl_primitive_from_native_impl!(u8, U8);
+xdl_primitive_from_native_impl!(u16, U16);
+xdl_primitive_from_native_impl!(u32, U32);
+xdl_primitive_from_native_impl!(u64, U64);
+xdl_primitive_from_native_impl!(u128, U128);
 
-xdl_primitive_from_impl!(i8, I8);
-xdl_primitive_from_impl!(i16, I16);
-xdl_primitive_from_impl!(i32, I32);
-xdl_primitive_from_impl!(i64, I64);
-xdl_primitive_from_impl!(i128, I128);
+xdl_primitive_from_native_impl!(i8, I8);
+xdl_primitive_from_native_impl!(i16, I16);
+xdl_primitive_from_native_impl!(i32, I32);
+xdl_primitive_from_native_impl!(i64, I64);
+xdl_primitive_from_native_impl!(i128, I128);
 
-xdl_primitive_from_impl!(f32, F32);
-xdl_primitive_from_impl!(f64, F64);
+xdl_primitive_from_native_impl!(f32, F32);
+xdl_primitive_from_native_impl!(f64, F64);
 
-xdl_primitive_from_impl!(String, String);
+xdl_primitive_from_native_impl!(String, String);
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    macro_rules! from_primitive_test {
+    macro_rules! primitive_from_native_test {
         ($ty:ty, $xdl_type:tt, $test_num:expr) => {
             let value: $ty = $test_num;
             let primitive: XdlPrimitive = value.clone().into();
@@ -66,21 +66,21 @@ mod test {
 
     #[test]
     fn primitive_from_native_works() {
-        from_primitive_test!(bool, Bool, true);
-        from_primitive_test!(bool, Bool, false);
-        from_primitive_test!(u8, U8, 42);
-        from_primitive_test!(u16, U16, 42);
-        from_primitive_test!(u32, U32, 42);
-        from_primitive_test!(u64, U64, 42);
-        from_primitive_test!(u128, U128, 42);
-        from_primitive_test!(i8, I8, 42);
-        from_primitive_test!(i16, I16, 42);
-        from_primitive_test!(i32, I32, 42);
-        from_primitive_test!(i64, I64, 42);
-        from_primitive_test!(i128, I128, 42);
-        from_primitive_test!(f32, F32, 42.0);
-        from_primitive_test!(f64, F64, 42.0);
-        from_primitive_test!(String, String, "Hello World".to_string());
+        primitive_from_native_test!(bool, Bool, true);
+        primitive_from_native_test!(bool, Bool, false);
+        primitive_from_native_test!(u8, U8, 42);
+        primitive_from_native_test!(u16, U16, 42);
+        primitive_from_native_test!(u32, U32, 42);
+        primitive_from_native_test!(u64, U64, 42);
+        primitive_from_native_test!(u128, U128, 42);
+        primitive_from_native_test!(i8, I8, 42);
+        primitive_from_native_test!(i16, I16, 42);
+        primitive_from_native_test!(i32, I32, 42);
+        primitive_from_native_test!(i64, I64, 42);
+        primitive_from_native_test!(i128, I128, 42);
+        primitive_from_native_test!(f32, F32, 42.0);
+        primitive_from_native_test!(f64, F64, 42.0);
+        primitive_from_native_test!(String, String, "Hello World".to_string());
     }
 
     #[test]

--- a/xdl_rs/src/lib.rs
+++ b/xdl_rs/src/lib.rs
@@ -21,7 +21,15 @@ trait DeserializeMetadata {
     fn deserialize_metadata(reader: &mut impl Read) -> io::Result<XdlMetadata>;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+trait IntoBaseMetadata {
+    fn into_base_metadata(self) -> XdlMetadata;
+}
+
+trait IntoBaseType {
+    fn into_base_type(self) -> XdlType;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum XdlMetadata {
     Primitive(XdlPrimitiveMetadata),
     Vec(XdlVecMetadata),

--- a/xdl_rs/src/lib.rs
+++ b/xdl_rs/src/lib.rs
@@ -1,4 +1,5 @@
 mod conversions;
+mod util;
 mod xdl_primitive;
 mod xdl_struct;
 mod xdl_vec;

--- a/xdl_rs/src/util.rs
+++ b/xdl_rs/src/util.rs
@@ -1,0 +1,7 @@
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{self, Write};
+
+pub fn write_string(string: &str, writer: &mut impl Write) -> io::Result<()> {
+    writer.write_u16::<LittleEndian>(string.len() as u16)?;
+    writer.write_all(string.as_bytes())
+}

--- a/xdl_rs/src/util.rs
+++ b/xdl_rs/src/util.rs
@@ -1,7 +1,14 @@
-use byteorder::{LittleEndian, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Write};
 
 pub fn write_string(string: &str, writer: &mut impl Write) -> io::Result<()> {
     writer.write_u16::<LittleEndian>(string.len() as u16)?;
     writer.write_all(string.as_bytes())
+}
+
+pub fn read_string(reader: &mut impl io::Read) -> io::Result<String> {
+    let len = reader.read_u16::<LittleEndian>()?;
+    let mut buf = vec![0; len as usize];
+    reader.read_exact(&mut buf)?;
+    String::from_utf8(buf).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid utf8"))
 }

--- a/xdl_rs/src/xdl_primitive/primitive.rs
+++ b/xdl_rs/src/xdl_primitive/primitive.rs
@@ -1,5 +1,8 @@
 use super::primitive_metadata::XdlPrimitiveMetadata;
-use crate::{util::write_string, Serialize, XdlType};
+use crate::{
+    util::{read_string, write_string},
+    Serialize, XdlType,
+};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
 
@@ -75,14 +78,7 @@ impl XdlPrimitive {
             XdlPrimitiveMetadata::I256 => unimplemented!(),
             XdlPrimitiveMetadata::F32 => reader.read_f32::<LittleEndian>().map(XdlPrimitive::F32),
             XdlPrimitiveMetadata::F64 => reader.read_f64::<LittleEndian>().map(XdlPrimitive::F64),
-            XdlPrimitiveMetadata::String => {
-                let len = reader.read_u16::<LittleEndian>()?;
-                let mut buf = vec![0; len as usize];
-                reader.read_exact(&mut buf)?;
-                let string = String::from_utf8(buf)
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid utf8"))?;
-                Ok(XdlPrimitive::String(string))
-            }
+            XdlPrimitiveMetadata::String => read_string(reader).map(XdlPrimitive::String),
         }
         .map(|x| x.into())
     }

--- a/xdl_rs/src/xdl_primitive/primitive.rs
+++ b/xdl_rs/src/xdl_primitive/primitive.rs
@@ -1,5 +1,5 @@
 use super::primitive_metadata::XdlPrimitiveMetadata;
-use crate::{Serialize, XdlType};
+use crate::{util::write_string, Serialize, XdlType};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
 
@@ -45,10 +45,7 @@ impl Serialize for XdlPrimitive {
             XdlPrimitive::F32(x) => writer.write_f32::<LittleEndian>(*x),
             XdlPrimitive::F64(x) => writer.write_f64::<LittleEndian>(*x),
 
-            XdlPrimitive::String(x) => {
-                writer.write_u16::<LittleEndian>(x.len() as u16)?;
-                writer.write_all(x.as_bytes())
-            }
+            XdlPrimitive::String(x) => write_string(x, writer),
         }
     }
 }

--- a/xdl_rs/src/xdl_struct.rs
+++ b/xdl_rs/src/xdl_struct.rs
@@ -1,9 +1,9 @@
 use crate::{XdlMetadata, XdlType};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XdlStructMetadata {
     _name: String,
-    // TODO: should this be a hashmap not a vec?
+    // TODO: add a hashmap for quick lookups
     _fields: Vec<(String, Box<XdlMetadata>)>,
 }
 

--- a/xdl_rs/src/xdl_vec/vec_metadata.rs
+++ b/xdl_rs/src/xdl_vec/vec_metadata.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 
 pub const VEC_METADATA_DISCRIMINANT: u8 = XdlPrimitiveMetadata::String as u8 + 1;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XdlVecMetadata {
     pub(crate) inner_type: Box<XdlMetadata>,
 }
@@ -31,7 +31,7 @@ impl Serialize for XdlVecMetadata {
 impl DeserializeMetadata for XdlVecMetadata {
     fn deserialize_metadata(reader: &mut impl io::Read) -> io::Result<XdlMetadata> {
         let inner_type = XdlMetadata::deserialize_metadata(reader)?;
-        Ok(XdlMetadata::Vec(XdlVecMetadata::new(inner_type)))
+        Ok(XdlVecMetadata::new(inner_type).into())
     }
 }
 


### PR DESCRIPTION
These functions get used for primitive string parsing and will also be used extensively in struct parsing as the struct and its fields will all have names that are sent as strings according to the XDL spec. I didn't add tests for these as they're covered according to cargo tarpaulin, and they get used in plenty of places where if they didn't work as expected those tests would break too.